### PR TITLE
Add argument parser and -n flag for number of simulations

### DIFF
--- a/MarchMadness_2023/lib/general.py
+++ b/MarchMadness_2023/lib/general.py
@@ -1,0 +1,8 @@
+import argparse
+
+def get_options():
+    """Get the command line options"""
+    parser = argparse.ArgumentParser(description='March Madness 2023')
+    parser.add_argument('-n', '--num-sims', help='Number of simulations to run', type=int, default=100_000)
+    
+    return parser.parse_args()

--- a/MarchMadness_2023/lib/graphs.py
+++ b/MarchMadness_2023/lib/graphs.py
@@ -72,7 +72,7 @@ def density_plot(points_lists, headliner, i, is_pre=False):
 
     if(var(Josh)):
         sns.kdeplot(Josh, linewidth=THICKNESS, color="tab:green")
-        legend_list.append(f"Joe:  {win_pcts['Josh']}")
+        legend_list.append(f"Josh:  {win_pcts['Josh']}")
 
     # if(var(Justin)):
     #     sns.kdeplot(Justin, linewidth=THICKNESS, color="tab:red")

--- a/MarchMadness_2023/simulate_pre.py
+++ b/MarchMadness_2023/simulate_pre.py
@@ -7,6 +7,7 @@ from lib.teams import *
 from lib.database import create_pre_tables, run_query
 from lib.simulate import sim_game, sim_many_tournaments
 from lib.graphs import density_plot, violin_plot
+from lib.general import get_options
 
 #########################################################################################################
 headliner = "Pre-Tournament"
@@ -192,7 +193,9 @@ def sim_tournament():
 
 
 if __name__ == '__main__':
+    opts = get_options()
+
     create_pre_tables(True)
-    points_lists = sim_many_tournaments(1_000, sim_tournament, is_pre=True)
+    points_lists = sim_many_tournaments(opts.num_sims, sim_tournament, is_pre=True)
     density_plot(points_lists, headliner, i, is_pre=True)
     violin_plot(i=i, is_pre=True)

--- a/MarchMadness_2023/simulate_tournament.py
+++ b/MarchMadness_2023/simulate_tournament.py
@@ -7,6 +7,7 @@ from lib.teams import *
 from lib.database import create_tables, run_query
 from lib.simulate import sim_game, sim_many_tournaments
 from lib.graphs import density_plot, violin_plot
+from lib.general import get_options
 
 #########################################################################################################
 headliner = "Gonzaga beats TCU"
@@ -192,8 +193,10 @@ def sim_tournament():
 
 
 if __name__ == '__main__':
+    opts = get_options()
+
     create_tables(True)
-    points_lists = sim_many_tournaments(10_000, sim_tournament)
+    points_lists = sim_many_tournaments(opts.num_sims, sim_tournament)
     density_plot(points_lists, headliner, i)
     violin_plot(i=i)
 


### PR DESCRIPTION
Add argument parser and -n flag for number of simulations

- 10,000 simulations as default if no `-n` flag is given
- use -n flag to specify number of sims e.g.: `python3.11 simulate_tournament.py -n 100000` for 100,000 simulations
- fixed legend: `Joe` was labeled twice, the first was supposed to be `Josh` 